### PR TITLE
Add forum link on the rest of the pages

### DIFF
--- a/autotown/autotuneresults.html
+++ b/autotown/autotuneresults.html
@@ -154,7 +154,7 @@
         <span>Menu</span></a>
 		<img class="img-centered" src="../assets/images/logos/logo_final_full.png" alt="dRonin" height="196" width="480">
       <nav class="m-header--nav js-header--list is-away">
-        <a href="/">Home</a><a href="http://dronin.readme.io">Documentation</a><a href="/autotown/autotuneresults.html"><i class="fi-graph-bar"></i>AutoTune Results</a><a target="_blank" href="http://kiwiirc.com/client/irc.kiwiirc.com/dronin/">IRC #dRonin</a><a target="_blank" href="https://github.com/d-ronin/dRonin"><i class="fi-social-github"></i>GitHub </a><a class="l-download" href="/releases/releases.html"><i class="fi-download"></i>Download </a>
+        <a href="/">Home</a><a href="http://dronin.readme.io">Documentation</a><a href="https://forum.dronin.org/forum">Forum</a><a href="/autotown/autotuneresults.html"><i class="fi-graph-bar"></i>AutoTune Results</a><a target="_blank" href="http://kiwiirc.com/client/irc.kiwiirc.com/dronin/">IRC #dRonin</a><a target="_blank" href="https://github.com/d-ronin/dRonin"><i class="fi-social-github"></i>GitHub </a><a class="l-download" href="/releases/releases.html"><i class="fi-download"></i>Download </a>
       </nav>
     </header>
  

--- a/releases/releases.html
+++ b/releases/releases.html
@@ -78,7 +78,7 @@
         <span>Menu</span></a>
 		<img class="img-centered" src="../assets/images/logos/logo_final_full.png" alt="dRonin" height="196" width="480">
       <nav class="m-header--nav js-header--list is-away">
-        <a href="/">Home</a><a href="http://dronin.readme.io">Documentation</a><a href="/autotown/autotuneresults.html"><i class="fi-graph-bar"></i>AutoTune Results</a><a target="_blank" href="http://kiwiirc.com/client/irc.kiwiirc.com/dronin/">IRC #dRonin</a><a target="_blank" href="https://github.com/d-ronin/dRonin"><i class="fi-social-github"></i>GitHub </a><a class="l-download" href="/releases/releases.html"><i class="fi-download"></i>Download </a>
+        <a href="/">Home</a><a href="http://dronin.readme.io">Documentation</a><a href="https://forum.dronin.org/forum">Forum</a><a href="/autotown/autotuneresults.html"><i class="fi-graph-bar"></i>AutoTune Results</a><a target="_blank" href="http://kiwiirc.com/client/irc.kiwiirc.com/dronin/">IRC #dRonin</a><a target="_blank" href="https://github.com/d-ronin/dRonin"><i class="fi-social-github"></i>GitHub </a><a class="l-download" href="/releases/releases.html"><i class="fi-download"></i>Download </a>
       </nav>
     </header>
     <div class="row">


### PR DESCRIPTION
Noticed that the forum link was only added to the homepage.  This should make the rest of the headers match