### PR TITLE
Tweaks to tunes dialog

### DIFF
--- a/assets/js/tunes.js
+++ b/assets/js/tunes.js
@@ -37,7 +37,7 @@ function generate_uavo(objs) {
     return new XMLSerializer().serializeToString(uav.documentElement);
 }
 
-var dronin = angular.module('dronin', ['ngMaterial'])
+var dronin = angular.module('dronin', ['ngMaterial', 'ngSanitize'])
     .filter('relDate', function() {
         return function(dstr) {
             return moment(dstr).fromNow();
@@ -66,6 +66,13 @@ var dronin = angular.module('dronin', ['ngMaterial'])
             });
         }
     })
+    .filter('simpleFormat', ['$filter', function($filter) {
+        // https://github.com/RStankov/angular-simple-format/blob/1d6f1f6acdac3dd709587eaee5dde361cf890622/lib/angular_simple_format.js
+        var linky = $filter('linky');
+        return function(text) {
+            return linky((text || '') + '').replace(/\&#10;/g, "&#10;<br>");
+        };
+    }])
     .config(function($mdThemingProvider) {
         $mdThemingProvider.theme('default')
             .primaryPalette('blue-grey')

--- a/assets/js/tunes.js
+++ b/assets/js/tunes.js
@@ -106,7 +106,7 @@ dronin.controller('AutotuneCtrl', function($scope, $http, $mdDialog) {
     );
 });
 
-dronin.controller('AutotuneDialogController', function($scope, $http, $httpParamSerializer, $mdDialog, tune) {
+dronin.controller('AutotuneDialogController', function($scope, $http, $httpParamSerializer, $mdDialog, tune, $window) {
     var $ctrl = this;
 
     $scope.closeDialog = function() {
@@ -162,6 +162,10 @@ dronin.controller('AutotuneDialogController', function($scope, $http, $httpParam
         }, objs);
         download('user-settings.uav', generate_uavo(objs));
     };
+
+    $ctrl.googleMaps = function(lat, lon) {
+        $window.location.href = 'https://www.google.com/maps/@' + lat + ',' + lon + ',12z';
+    }
 
     $http.get(autotown_api(['tune?' + $httpParamSerializer({tune: tune})])).
         then(function successCallback(response) {

--- a/tunes.html
+++ b/tunes.html
@@ -80,7 +80,7 @@ intro:
                     <img src="/assets/images/ic_location_on_24px.svg" class="md-avatar">
                     <div class="md-list-item-text">
                       <h3>
-                        <a ng-href="https://www.google.com/maps/@{{ tune.Lat }},{{ tune.Lon }},12z">
+                        <a ng-click="$ctrl.googleMaps(tune.Lat, tune.Lon)">
                           <span ng-bind="tune.City | titleCase"></span>, <span ng-bind="tune.Region | uppercase"></span>, <span ng-bind="tune.Country | uppercase"></span>
                         </a>
                       </h3>

--- a/tunes.html
+++ b/tunes.html
@@ -13,6 +13,9 @@ addl_headers: |
     [x-ng-click] {
       cursor: pointer;
     }
+    br {
+      display: unset !important; /* the theme disables br tag for unknown reasons */
+    }
   </style>
 header:
   overlay_filter: rgba(173, 94, 0, 0.735)
@@ -123,7 +126,7 @@ intro:
               <md-content class="md-padding">
                 <h2 style="margin: 0">Settings</h2>
                 <div>
-                  <md-list layout="row">
+                  <md-list layout="row" layout-xs="column">
                     <md-list-item class="md-2-line">
                       <div class="md-list-item-text">
                         <h3 ng-bind="tune.Orig.tuning.parameters.damping | number: 2"></h3>
@@ -140,7 +143,7 @@ intro:
                 </div>
                 <h2 style="margin: 0">Results</h2>
                 <div>
-                  <md-list layout="row">
+                  <md-list layout="row" layout-xs="column">
                     <md-list-item class="md-2-line">
                       <div class="md-list-item-text">
                         <h3><span ng-bind="tune.Orig.tuning.computed.naturalFrequency | number: 1"></span> Hz</h3>
@@ -171,6 +174,8 @@ intro:
                     </tbody>
                   </table>
                 </div>
+                <h2 style="margin: 0">User Observations</h2>
+                <p ng-bind-html="tune.Orig.userObservations | simpleFormat"></p>
               </md-content>
             </md-tab>
             <md-tab label="vehicle">
@@ -231,12 +236,6 @@ intro:
                     </div>
                   </md-list-item>
                 </md-list>
-                <md-list-item class="md-2-line">
-                    <div class="md-list-item-text">
-                      <h3 ng-bind="tune.Orig.userObservations"></h3>
-                      <p>User Observations</p>
-                    </div>
-                  </md-list-item>
               </md-content>
             </md-tab>
             <md-tab label="uavobjects">
@@ -283,7 +282,7 @@ intro:
               </md-content>
               <md-dialog-actions layout="row">
                 <span flex></span>
-                <md-button class="md-raised md-primary" ng-click="$ctrl.downloadRawObjects()">
+                <md-button class="md-raised md-primary" ng-click="$ctrl.downloadRawObjects()" ng-disabled="selectedObjects.length==0">
                   <md-icon md-svg-src="assets/images/ic_file_download_24px.svg"></md-icon>
                   Download Selected UAVObjects
                 </md-button>
@@ -302,6 +301,7 @@ intro:
 <script src="//ajax.googleapis.com/ajax/libs/angularjs/1.5.7/angular-animate.min.js"></script>
 <script src="//ajax.googleapis.com/ajax/libs/angularjs/1.5.7/angular-aria.min.js"></script>
 <script src="//ajax.googleapis.com/ajax/libs/angularjs/1.5.7/angular-messages.min.js"></script>
+<script src="//ajax.googleapis.com/ajax/libs/angularjs/1.5.7/angular-sanitize.js"></script>
 <script src="//ajax.googleapis.com/ajax/libs/angular_material/1.1.0/angular-material.min.js"></script>
 <script src="//cdnjs.cloudflare.com/ajax/libs/moment.js/2.17.1/moment-with-locales.min.js"></script>
 <script src="/assets/js/tunes.js"></script>


### PR DESCRIPTION
* Google Maps links were still broken as Jekyll even interferes with ng's attributes
* Move user observations to the tune tab with the gains etc. Seems to make more sense.
* A couple of other minor appearance tweaks