### PR TITLE
Docs:Dev: Add supported compiler/os details

### DIFF
--- a/_docs/development-setup/development-setup-linux.md
+++ b/_docs/development-setup/development-setup-linux.md
@@ -8,6 +8,8 @@ Consider forking the project on GitHub before proceeding with this procedure if 
 
 ## Setting up prerequisites for the build environment
 
+{% include callout type="warning_full" title="GCS Compiler Requirements" text="GCS requires a compiler with C++11 support. GCC 4.8, 4.9 and 5.3 are fully supported. Ubuntu release 14.04 or newer meet this requirement by default. See the [Qt supported platforms list](http://doc.qt.io/archives/qt-5.8/supported-platforms.html#supported-configurations) for further details." %}
+
 ### Ubuntu/Mint/Debian based distributions
 
 First ensure your package manager is up to date:
@@ -27,8 +29,6 @@ If you are running a 64-bit version of Linux (if you run `uname -m` and the outp
 ```
 sudo apt-get install gcc-multilib
 ```
-
-{% include callout type="warning_full" title="GCC C++11 Support" text="GCS requires C++11 support through the flag `std=c++11` which was introduced in GCC 4.7.  Ubuntu release 14.04 or newer meet this requirement by default.  Building with older compilers is not supported." %}
 
 Finally, install some additional libraries required to compile GCS
 

--- a/_docs/development-setup/development-setup-os-x.md
+++ b/_docs/development-setup/development-setup-os-x.md
@@ -8,6 +8,8 @@ Building on OS X is relatively easy.  Consider forking the project on GitHub bef
 
 ## Setting up prerequesites for the build environment
 
+{% include callout type="warning_full" title="Supported macOS Versions" text="GCS requires macOS 10.10 or newer. See the [Qt supported platforms list](http://doc.qt.io/archives/qt-5.8/supported-platforms.html#supported-configurations) for further details." %}
+
 ### Get Homebrew
 
 Homebrew is a package manager; it's the best way to get some of the prerequisites to build dRonin.
@@ -76,7 +78,7 @@ Be sure to copy the specified path into the installer when prompted for the inst
 
 ### Arm cross compilation toolchain
 
-This is easy.  Just type: 
+This is easy.  Just type:
 
 ```
 make arm_sdk_install

--- a/_docs/development-setup/development-setup-windows.md
+++ b/_docs/development-setup/development-setup-windows.md
@@ -8,6 +8,8 @@ This page describes the procedures for setting up a Windows machine to compile d
 
 ## Setting up prerequisites for the build environment
 
+{% include callout type="warning_full" title="Supported Windows Versions" text="GCS requires Windows 7 or newer. See the [Qt supported platforms list](http://doc.qt.io/archives/qt-5.8/supported-platforms.html#supported-configurations) for further details." %}
+
 ### Download Required Programs
 
 [Git 2.6.4 or later](https://github.com/git-for-windows/git/releases) - The latest release should be fine.
@@ -24,7 +26,7 @@ Microsoft Visual Studio 2015 Community Edition - https://www.visualstudio.com/en
 
 * Install git. Default options are okay. You will use this to clone the dRonin repository to your machine. It also provides a bash shell and other Unix-like tools.
 * Install Python 2.7.x Anaconda distribution. Default options are okay. Python is used at various stages in the build process for both GCS and firmware.
-* Install Qt SDK. 
+* Install Qt SDK.
 
 {% include figure image_path="/assets/images/docs/5275df8-qtstep1.png" alt="Step 1" %}
 
@@ -69,7 +71,7 @@ git clone git://github.com/d-ronin/dRonin.git
 cd dRonin
 ```
 
-Type these command to install a bash_profile suitable for developing the project: 
+Type these command to install a bash_profile suitable for developing the project:
 
 ```
 cp make/winx86/bash_profile ~/.bash_profile
@@ -82,7 +84,7 @@ You may have to edit bash_profile if you have changed any installation paths fro
 exit
 ```
 
-### Automatic download and install of required programs 
+### Automatic download and install of required programs
 
 The dRonin build environment is capable of installing the rest of the tools that it needs.
 


### PR DESCRIPTION
Current Linux docs aren't enough for Qt 5.8, and mac + Windows were missing this entirely.