### PR TITLE
Docs:Dev: Cleanup titles, bring updates from readme.io

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -49,7 +49,7 @@ docs:
         url: /docs/development-setup/development-setup-linux/
       - title: "Dev Setup: Windows"
         url: /docs/development-setup/development-setup-windows/
-      - title: "Dev Setup: MacOS"
+      - title: "Dev Setup: macOS"
         url: /docs/development-setup/development-setup-os-x/
       - title: "Writing Bug Reports"
         url: /docs/development-setup/writing-good-bug-reports/

--- a/_docs/development-setup/development-setup-linux.md
+++ b/_docs/development-setup/development-setup-linux.md
@@ -6,11 +6,11 @@ excerpt: "So you want to be a dRonin?"
 
 Consider forking the project on GitHub before proceeding with this procedure if you intend to contribute back to the project.  (More details on this are at [Tracking Development with Git](doc:tracking-development-with-git))
 
-## Build Environment Prerequisites
+## Build environment prerequisites
 
 {% include callout type="warning_full" title="GCS Compiler Requirements" text="GCS requires a compiler with C++11 support. GCC 4.8, 4.9 and 5.3 are fully supported. Ubuntu release 14.04 or newer meet this requirement by default. See the [Qt supported platforms list](http://doc.qt.io/archives/qt-5.8/supported-platforms.html#supported-configurations) for further details." %}
 
-### Ubuntu/Mint/Debian Based Distributions
+### Ubuntu/Mint/Debian derived distributions
 
 First ensure your package manager is up to date:
 
@@ -45,9 +45,9 @@ Install the required packages (XXX doesn't look correct, we supply Qt headers an
     sudo dnf install libusb-devel qt5-qtdeclarative-devel qt5-qtimageformats qt5-qtserialport-devel qt5-qtsvg-devel qt5-qtxmlpatterns-devel SDL-devel systemd-devel zlib-devel
 ```
 
-## Fetching Source Code and Building
+## Fetching source code and building
 
-### Cloning the Source Code Repository
+### Cloning the repository
 
 First, clone the dRonin repository.  Change to an appropriate directory to check out the code.  If you have your own fork, specify its URL on the git command line (otherwise you can use the parent fork per the below example).
 
@@ -56,11 +56,11 @@ git clone git://github.com/d-ronin/dRonin.git
 cd dRonin
 ```
 
-## Automatic Download and Install of Required Programs
+## Automatic download and install of prerequisites
 
 The dRonin build environment is capable of installing the rest of the tools that it needs.
 
-### GCS Build Tools
+### GCS build tools
 
 Next, run `make qt_sdk_install`, copy the path from the output in your terminal and paste it into the installer when prompted.
 
@@ -83,7 +83,7 @@ Be sure to copy the specified path into the installer when prompted for the inst
 
 GCS uses Google Breakpad for crash-reporting. Rather than compiling this every time you build GCS, it is built once during toolchain setup. Run `make breakpad_install`.
 
-### Flight Firmware Build Tools
+### Flight firmware build tools
 
 This is easy.  Just type: `make arm_sdk_install`
 
@@ -93,11 +93,11 @@ FlyingPi requires additional steps to cross-compile the dRonin flight stack for 
 
 {% include callout type="warning_full" title="Building for Raspberry Pi?" text=flyingpi %}
 
-## Building the Software
+## Building the software
 
 You should be ready to go. Type `make all` to compile the entire project. Type `make` to see a list of possible make arguments.
 
-## Installing udev Rules
+## Installing udev rules
 
 You need to grant permission for normal users (ie. not root) to access your flight-controller boards from the GCS. This is accomplished by installing specific udev rules for the various flight controller boards.
 

--- a/_docs/development-setup/development-setup-linux.md
+++ b/_docs/development-setup/development-setup-linux.md
@@ -6,11 +6,11 @@ excerpt: "So you want to be a dRonin?"
 
 Consider forking the project on GitHub before proceeding with this procedure if you intend to contribute back to the project.  (More details on this are at [Tracking Development with Git](doc:tracking-development-with-git))
 
-## Setting up prerequisites for the build environment
+## Build Environment Prerequisites
 
 {% include callout type="warning_full" title="GCS Compiler Requirements" text="GCS requires a compiler with C++11 support. GCC 4.8, 4.9 and 5.3 are fully supported. Ubuntu release 14.04 or newer meet this requirement by default. See the [Qt supported platforms list](http://doc.qt.io/archives/qt-5.8/supported-platforms.html#supported-configurations) for further details." %}
 
-### Ubuntu/Mint/Debian based distributions
+### Ubuntu/Mint/Debian Based Distributions
 
 First ensure your package manager is up to date:
 
@@ -21,10 +21,10 @@ sudo apt-get update
 Next, get a host compiler and other build tools, along with your revision control environment:
 
 ```
-sudo apt-get install build-essential gdb wget debhelper ccache git libpulse-dev
+sudo apt-get install build-essential gdb wget debhelper ccache git
 ```
 
-If you are running a 64-bit version of Linux (if you run `uname -m` and the output says `x86_64` you are in a 64-bit environment), you'll also need to install 32-bit compatibility libraries. 
+If you are running a 64-bit version of Linux (if you run `uname -m` and the output says `x86_64` you are in a 64-bit environment), you'll also need to install 32-bit compatibility libraries.
 
 ```
 sudo apt-get install gcc-multilib
@@ -36,18 +36,18 @@ Finally, install some additional libraries required to compile GCS
 sudo apt-get install zlib1g-dev libusb-1.0-0-dev libudev-dev libgl1-mesa-dev libpulse-dev
 ```
 
-### Fedora-based Distributions
+### Fedora-Based Distributions
 
-Install the required packages:
+Install the required packages (XXX doesn't look correct, we supply Qt headers and binaries):
 
 ```
     sudo dnf install libstdc++.i686 gcc-c++ ccache
     sudo dnf install libusb-devel qt5-qtdeclarative-devel qt5-qtimageformats qt5-qtserialport-devel qt5-qtsvg-devel qt5-qtxmlpatterns-devel SDL-devel systemd-devel zlib-devel
 ```
 
-## Checking out the dRonin repository and building
+## Fetching Source Code and Building
 
-### Cloning the source code repository
+### Cloning the Source Code Repository
 
 First, clone the dRonin repository.  Change to an appropriate directory to check out the code.  If you have your own fork, specify its URL on the git command line (otherwise you can use the parent fork per the below example).
 
@@ -56,11 +56,11 @@ git clone git://github.com/d-ronin/dRonin.git
 cd dRonin
 ```
 
-## Automatic download and install of required programs
+## Automatic Download and Install of Required Programs
 
 The dRonin build environment is capable of installing the rest of the tools that it needs.
 
-### Qt build tools
+### GCS Build Tools
 
 Next, run `make qt_sdk_install`, copy the path from the output in your terminal and paste it into the installer when prompted.
 
@@ -81,40 +81,43 @@ Be sure to copy the specified path into the installer when prompted for the inst
 
 {% include callout type="warning_full" title="Don't install Qt to the default location!" text=sdkinst %}
 
-### ARM cross compilation toolchain
+GCS uses Google Breakpad for crash-reporting. Rather than compiling this every time you build GCS, it is built once during toolchain setup. Run `make breakpad_install`.
+
+### Flight Firmware Build Tools
 
 This is easy.  Just type: `make arm_sdk_install`
 
-## Building the software
+{% capture flyingpi %}
+FlyingPi requires additional steps to cross-compile the dRonin flight stack for arm-linux. See [setup guide](https://github.com/d-ronin/dRonin/wiki/User-Guide:-FlyingPI-Setup) for further information.
+{% endcapture %}
 
-You should be ready to go. Type `make all` to compile the entire project. Type `make` to see a list of possible make arguments. 
+{% include callout type="warning_full" title="Building for Raspberry Pi?" text=flyingpi %}
 
-## Installing udev rules
+## Building the Software
+
+You should be ready to go. Type `make all` to compile the entire project. Type `make` to see a list of possible make arguments.
+
+## Installing udev Rules
 
 You need to grant permission for normal users (ie. not root) to access your flight-controller boards from the GCS. This is accomplished by installing specific udev rules for the various flight controller boards.
 
-Check if your user is in the group "plugdev" by running 'groups'
-
-{% capture plugdev %}
-You can add the group plugdev to your user by running this command:
+The udev rules are generated dynamically (from the file shared/usb_ids/usb_ids.json). To generate dRonin udev rules, copy them to your system and load them, run these commands:
 
 ```
-sudo usermod -a -G plugdev user
+make usb_id_udev
+sudo cp build/shared/usb_ids/dronin.udev /etc/udev/rules.d/45-dronin-permissions.rules
 ```
-
-Then, log-out and log back in and check again by running `groups`
-{% endcapture %}
-
-{% include callout type="warning_full" title="If you're not in group \"plugdev\"..." text=plugdev %}
-
-Next, run these commands to install the dRonin udev rules:
-
+and then:
 ```
-XXX no longer accurate
-sudo cp package/linux/deb/_package.udev /etc/udev/rules.d/45-dronin-permissions.rules
 sudo udevadm control --reload-rules
 ```
 
+{% capture replug_board %}
+You must disconnect and reconnect devices if they were already plugged in when you loaded the udev rules.
+{% endcapture %}
+
+{% include callout type="info_full" title="Device still not accessible?" text=replug_board %}
+
 ## Running GCS
 
-Launch the gcs with `./build/ground/gcs/bin/drgcs` and connect to / flash your board.
+Launch the gcs with `./build/ground/gcs/bin/drgcs` and connect to/flash your board.

--- a/_docs/development-setup/development-setup-os-x.md
+++ b/_docs/development-setup/development-setup-os-x.md
@@ -89,26 +89,3 @@ You should be ready to go. Type `make all` to compile the entire project. Type `
 ## Running GCS
 
 Launch the gcs with `open build/ground/gcs/bin/dRonin-GCS.app` and connect to / flash your board.
-
-## Eclipse Setup (Optional)
-
-Extract the eclipse project:
-
-```
-pushd flight/Project/Eclipse
-unzip eclipseLinuxWsp.zip -d eclipseLinuxWsp
-mv eclipseLinuxWsp/.metadata ../../../
-mv eclipseLinuxWsp/.cproject ../../
-mv eclipseLinuxWsp/.project ../../
-mkdir ../../../tools/eclipseWorkspace
-```
-
-Install eclipse, use the `Eclipse Installer`: https://eclipse.org/downloads/
-
-Choose the `Eclipse IDE for C/C++ Developers` when prompted
-
-When Eclipse starts, choose the folder you created in `[Your Project Root]/tools/eclipseWorkspace` as the workspace directory.
-
-Then choose `File` -> `Import` and pick `Import an Existing Project`. Choose your project root directory, which is the same place you checked out the project with git.
-
-You'll see the two projects `android gcs` and `flight` appear. Hit `Finish` and you're good to go!

--- a/_docs/development-setup/development-setup-os-x.md
+++ b/_docs/development-setup/development-setup-os-x.md
@@ -6,7 +6,7 @@ excerpt: "So you want to be a dRonin?"
 
 Building on macOS is relatively easy.  Consider forking the project on GitHub before proceeding with this procedure if you intend to contribute back to the project.  (More details on this are at [Tracking Development with Git](doc:tracking-development-with-git))
 
-## Build Environment Prerequisites
+## Build environment prerequisites
 
 {% include callout type="warning_full" title="Supported macOS Versions" text="GCS requires macOS 10.10 or newer. See the [Qt supported platforms list](http://doc.qt.io/archives/qt-5.8/supported-platforms.html#supported-configurations) for further details." %}
 
@@ -32,15 +32,15 @@ Then, you can use homebrew to install wget:
 brew install wget
 ```
 
-### Download Required Programs
+### Download required programs
 
 Xcode. If you do not already have Xcode, the latest version can be obtained from the Apple app store.
 
 After this, start Xcode and go through the initial setup. Once Xcode is running, go to Xcode > Preferences > Downloads > Components and install "Command Line Tools".
 
-## Fetching Source Code and Building
+## Fetching source code and building
 
-### Cloning the Source Code Repository
+### Cloning the repository
 
 First, clone the dRonin repository.  If you have your own fork, specify it on the git command line.
 
@@ -49,11 +49,11 @@ git clone git://github.com/d-ronin/dRonin.git
 cd dRonin
 ```
 
-## Automatic Download and Install of Required Programs
+## Automatic download and install of prerequisites
 
 The dRonin build environment is capable of installing the rest of the tools that it needs.
 
-### GCS Build Tools
+### GCS build tools
 
 {% include callout type="warning_full" title="Removing existing Qt build locations!" text="If you have brew installed qt previously, unlink it now. If you get link errors building uavobjects, this is probably what is wrong: `brew unlink qt`" %}
 
@@ -78,11 +78,11 @@ Be sure to copy the specified path into the installer when prompted for the inst
 
 GCS uses Google Breakpad for crash-reporting. Rather than compiling this every time you build GCS, it is built once during toolchain setup. Run `make breakpad_install`.
 
-### Flight Firmware Build Tools
+### Flight firmware build tools
 
 This is easy.  Just type: `make arm_sdk_install`
 
-## Building the Software
+## Building the software
 
 You should be ready to go. Type `make all` to compile the entire project. Type `make` to see a list of possible make arguments.
 

--- a/_docs/development-setup/development-setup-os-x.md
+++ b/_docs/development-setup/development-setup-os-x.md
@@ -1,12 +1,12 @@
 ---
-title: "Development Setup: MacOS"
+title: "Development Setup: macOS"
 excerpt: "So you want to be a dRonin?"
 ---
 {% include toc %}
 
-Building on OS X is relatively easy.  Consider forking the project on GitHub before proceeding with this procedure if you intend to contribute back to the project.  (More details on this are at [Tracking Development with Git](doc:tracking-development-with-git))
+Building on macOS is relatively easy.  Consider forking the project on GitHub before proceeding with this procedure if you intend to contribute back to the project.  (More details on this are at [Tracking Development with Git](doc:tracking-development-with-git))
 
-## Setting up prerequesites for the build environment
+## Build Environment Prerequisites
 
 {% include callout type="warning_full" title="Supported macOS Versions" text="GCS requires macOS 10.10 or newer. See the [Qt supported platforms list](http://doc.qt.io/archives/qt-5.8/supported-platforms.html#supported-configurations) for further details." %}
 
@@ -38,9 +38,9 @@ Xcode. If you do not already have Xcode, the latest version can be obtained from
 
 After this, start Xcode and go through the initial setup. Once Xcode is running, go to Xcode > Preferences > Downloads > Components and install "Command Line Tools".
 
-## Checking out the dRonin repository and building
+## Fetching Source Code and Building
 
-### Clone the source code repository
+### Cloning the Source Code Repository
 
 First, clone the dRonin repository.  If you have your own fork, specify it on the git command line.
 
@@ -49,11 +49,11 @@ git clone git://github.com/d-ronin/dRonin.git
 cd dRonin
 ```
 
-### Automatic download and install of required programs
+## Automatic Download and Install of Required Programs
 
 The dRonin build environment is capable of installing the rest of the tools that it needs.
 
-### Qt build tools
+### GCS Build Tools
 
 {% include callout type="warning_full" title="Removing existing Qt build locations!" text="If you have brew installed qt previously, unlink it now. If you get link errors building uavobjects, this is probably what is wrong: `brew unlink qt`" %}
 
@@ -76,17 +76,15 @@ Be sure to copy the specified path into the installer when prompted for the inst
 
 {% include callout type="warning_full" title="Don't install Qt to the default location!" text=sdkinst %}
 
-### Arm cross compilation toolchain
+GCS uses Google Breakpad for crash-reporting. Rather than compiling this every time you build GCS, it is built once during toolchain setup. Run `make breakpad_install`.
 
-This is easy.  Just type:
+### Flight Firmware Build Tools
 
-```
-make arm_sdk_install
-```
+This is easy.  Just type: `make arm_sdk_install`
 
-## Building the software
+## Building the Software
 
-You should be ready to go. Type `make all` to compile the entire project. Type `make` to see a list of possible make arguments. Use 'make package' to create a .dmg containing everything, ready to install.
+You should be ready to go. Type `make all` to compile the entire project. Type `make` to see a list of possible make arguments.
 
 ## Running GCS
 

--- a/_docs/development-setup/development-setup-windows.md
+++ b/_docs/development-setup/development-setup-windows.md
@@ -6,11 +6,11 @@ excerpt: "So you want to be a dRonin?"
 
 This page describes the procedures for setting up a Windows machine to compile dRonin firmware and GCS software. (More details on this are at [Tracking Development with Git](doc:tracking-development-with-git))
 
-## Build Environment Prerequisites
+## Build environment prerequisites
 
 {% include callout type="warning_full" title="Supported Windows Versions" text="GCS requires Windows 7 or newer. See the [Qt supported platforms list](http://doc.qt.io/archives/qt-5.8/supported-platforms.html#supported-configurations) for further details." %}
 
-### Download Required Programs
+### Download required programs
 
 [Git 2.6.4 or later](https://github.com/git-for-windows/git/releases) - The latest release should be fine.
 
@@ -20,7 +20,7 @@ Qt 5.6.1 (online installer) - http://download.qt.io/official_releases/online_ins
 
 Microsoft Visual Studio 2015 Community Edition - https://www.visualstudio.com/en-us/products/visual-studio-community-vs.aspx. __Do not__ install an older or newer release, as it will not work. MSVC is used to compile GCS on Windows.
 
-### Install Required Programs
+### Install required programs
 
 {% include callout type="warning" title="Default install paths" text="The bash_profile provided by dRonin is built to use default install paths. Please keep default paths while installing tools unless you are prepared to edit the bash profile by hand. Read the following steps carefully to avoid problems." %}
 
@@ -58,9 +58,9 @@ Microsoft Visual Studio 2015 Community Edition - https://www.visualstudio.com/en
 
 * Install/accept UAC prompt.
 
-## Fetching Source Code and Building
+## Fetching source code and building
 
-### Cloning the Source Code Repository
+### Cloning the repository
 
 Start a shell using the "Git bash" program shortcut.
 
@@ -84,7 +84,7 @@ You may have to edit bash_profile if you have changed any installation paths fro
 exit
 ```
 
-## Automatic Download and Install of Required Programs
+## Automatic download and install of prerequisites
 
 The dRonin build environment is capable of installing the rest of the tools that it needs.
 
@@ -105,7 +105,7 @@ qbs setup-toolchains --detect
 
 GCS uses Google Breakpad for crash-reporting. Rather than compiling this every time you build GCS, it is built once during toolchain setup. Run `make breakpad_install`.
 
-## Building the Software
+## Building the software
 
 You should be ready to go. Type `make all` to compile the entire project. Type `make` to see a list of possible make arguments.
 

--- a/_docs/development-setup/development-setup-windows.md
+++ b/_docs/development-setup/development-setup-windows.md
@@ -6,7 +6,7 @@ excerpt: "So you want to be a dRonin?"
 
 This page describes the procedures for setting up a Windows machine to compile dRonin firmware and GCS software. (More details on this are at [Tracking Development with Git](doc:tracking-development-with-git))
 
-## Setting up prerequisites for the build environment
+## Build Environment Prerequisites
 
 {% include callout type="warning_full" title="Supported Windows Versions" text="GCS requires Windows 7 or newer. See the [Qt supported platforms list](http://doc.qt.io/archives/qt-5.8/supported-platforms.html#supported-configurations) for further details." %}
 
@@ -58,9 +58,9 @@ Microsoft Visual Studio 2015 Community Edition - https://www.visualstudio.com/en
 
 * Install/accept UAC prompt.
 
-## Checking out the dRonin repository and building
+## Fetching Source Code and Building
 
-### Clone the source code repository
+### Cloning the Source Code Repository
 
 Start a shell using the "Git bash" program shortcut.
 
@@ -84,7 +84,7 @@ You may have to edit bash_profile if you have changed any installation paths fro
 exit
 ```
 
-### Automatic download and install of required programs
+## Automatic Download and Install of Required Programs
 
 The dRonin build environment is capable of installing the rest of the tools that it needs.
 
@@ -97,24 +97,17 @@ make openssl_install
 make zip_install
 ```
 
-Next, it's necessary to configure qbs:
+Next, it's necessary to configure qbs (XXX I'm not sure this is necessary anymore):
 
 ```
 qbs setup-toolchains --detect
 ```
 
-If you wish to build packages for distribution (not recommended unless you know what you're doing), you will also need to install breakpad.
-```
-make breakpad_install
-```
+GCS uses Google Breakpad for crash-reporting. Rather than compiling this every time you build GCS, it is built once during toolchain setup. Run `make breakpad_install`.
 
-## Building the software
+## Building the Software
 
-After this you can compile everything with the following commad!
-
-```
-make all
-```
+You should be ready to go. Type `make all` to compile the entire project. Type `make` to see a list of possible make arguments.
 
 ## Running GCS
 


### PR DESCRIPTION
Done:
- Fix up various title caps
- Unify the three a bit
- Bring up-to-date udev instructions from readme.io
- Remove unmaintained Eclipse project from macOS instructions

Not done:
- Fedora package list doesn't look correct, esp. qt headers + libs which we supply ourselves!
- `qbs setup-toolchains --detect` is no longer necessary on Windows AFAIK? [This rule](https://github.com/d-ronin/dRonin/blob/next/make/tools.mk#L628) should take care of it.